### PR TITLE
Add resilient PDF export loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# invoice
-invoice v2
+# Invoice Generator
+
+Single-page application for creating and exporting invoices.
+
+## Usage
+
+1. Open the `index.html` file in your browser.
+2. Fill in the seller, client, invoice details, and line items.
+3. All values are saved to the browser automatically and restored the next time you open the page.
+4. Click **Export PDF** to save the current invoice preview as a PDF file.
+
+To serve the files locally you can use any static server, for example:
+
+```bash
+python3 -m http.server 3000
+```
+
+After that the page will be available at <http://localhost:3000/index.html>.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Invoice Generator</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" type="text/css" href="./styles.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="page__header">
+        <h1 class="page__title">Invoice Generator</h1>
+        <div class="page__actions">
+          <button
+            id="downloadPdf"
+            type="button"
+            class="button button--primary"
+          >
+            Export PDF
+          </button>
+          <button id="resetState" class="button button--secondary">
+            Reset data
+          </button>
+        </div>
+      </header>
+      <main class="page__content">
+        <section class="panel">
+          <h2 class="panel__title">Invoice data</h2>
+          <form id="invoiceForm" class="form" autocomplete="off">
+            <fieldset class="fieldset">
+              <legend class="fieldset__title">Seller</legend>
+              <div class="field">
+                <label for="sellerName" class="field__label">Name / Company</label>
+                <input id="sellerName" name="sellerName" class="field__input" />
+              </div>
+              <div class="field">
+                <label for="sellerAddress" class="field__label">Address</label>
+                <textarea id="sellerAddress" name="sellerAddress" class="field__input field__input--textarea"></textarea>
+              </div>
+              <div class="field">
+                <label for="sellerPhone" class="field__label">Phone</label>
+                <input id="sellerPhone" name="sellerPhone" class="field__input" />
+              </div>
+              <div class="field">
+                <label for="sellerEmail" class="field__label">Email</label>
+                <input id="sellerEmail" name="sellerEmail" type="email" class="field__input" />
+              </div>
+            </fieldset>
+
+            <fieldset class="fieldset">
+              <legend class="fieldset__title">Client</legend>
+              <div class="field">
+                <label for="clientName" class="field__label">Name / Company</label>
+                <input id="clientName" name="clientName" class="field__input" />
+              </div>
+              <div class="field">
+                <label for="clientContact" class="field__label">Contact details</label>
+                <textarea id="clientContact" name="clientContact" class="field__input field__input--textarea"></textarea>
+              </div>
+            </fieldset>
+
+            <fieldset class="fieldset">
+              <legend class="fieldset__title">Invoice information</legend>
+              <div class="field field--grid">
+                <div>
+                  <label for="invoiceNumber" class="field__label">Number</label>
+                  <input id="invoiceNumber" name="invoiceNumber" class="field__input" />
+                </div>
+                <div>
+                  <label for="issueDate" class="field__label">Issue date</label>
+                  <input id="issueDate" name="issueDate" type="date" class="field__input" />
+                </div>
+                <div>
+                  <label for="dueDate" class="field__label">Due date</label>
+                  <input id="dueDate" name="dueDate" type="date" class="field__input" />
+                </div>
+                <div>
+                  <label for="currency" class="field__label">Currency</label>
+                  <input id="currency" name="currency" maxlength="5" class="field__input" />
+                </div>
+                <div>
+                  <label for="paymentTerms" class="field__label">Payment terms</label>
+                  <input id="paymentTerms" name="paymentTerms" class="field__input" />
+                </div>
+                <div>
+                  <label for="balanceDue" class="field__label">Balance due</label>
+                  <input id="balanceDue" name="balanceDue" type="number" step="0.01" class="field__input" />
+                </div>
+              </div>
+            </fieldset>
+
+            <fieldset class="fieldset">
+              <legend class="fieldset__title">Line items</legend>
+              <div id="itemsContainer" class="items"></div>
+              <button type="button" id="addItem" class="button button--ghost">Add line item</button>
+            </fieldset>
+
+            <fieldset class="fieldset">
+              <legend class="fieldset__title">Notes</legend>
+              <div class="field">
+                <label for="notes" class="field__label">Additional notes</label>
+                <textarea id="notes" name="notes" class="field__input field__input--textarea"></textarea>
+              </div>
+            </fieldset>
+          </form>
+        </section>
+
+        <section class="panel panel--preview">
+          <h2 class="panel__title">Preview</h2>
+          <div id="invoicePreview" class="invoice">
+            <header class="invoice__header">
+              <div class="invoice__seller">
+                <div class="invoice__seller-name" data-field="sellerName"></div>
+                <div class="invoice__seller-address" data-field="sellerAddress"></div>
+                <div class="invoice__seller-contact">
+                  <div data-field="sellerPhone"></div>
+                  <div data-field="sellerEmail"></div>
+                </div>
+              </div>
+              <div class="invoice__meta">
+                <div class="invoice__title">Invoice</div>
+                <div class="invoice__number">
+                  <span class="invoice__label">Number</span>
+                  <span data-field="invoiceNumber"></span>
+                </div>
+                <div class="invoice__balance">
+                  <span class="invoice__label">Balance due</span>
+                  <span data-field="balanceDue"></span>
+                </div>
+              </div>
+            </header>
+
+            <div class="invoice__info">
+              <div class="invoice__info-block">
+                <div class="invoice__label">Issue date</div>
+                <div data-field="issueDate"></div>
+              </div>
+              <div class="invoice__info-block">
+                <div class="invoice__label">Due date</div>
+                <div data-field="dueDate"></div>
+              </div>
+              <div class="invoice__info-block">
+                <div class="invoice__label">Terms</div>
+                <div data-field="paymentTerms"></div>
+              </div>
+              <div class="invoice__info-block">
+                <div class="invoice__label">Currency</div>
+                <div data-field="currency"></div>
+              </div>
+            </div>
+
+            <div class="invoice__billto">
+              <div class="invoice__label">Bill to</div>
+              <div class="invoice__billto-name" data-field="clientName"></div>
+              <div class="invoice__billto-contact" data-field="clientContact"></div>
+            </div>
+
+            <table class="invoice__table">
+              <thead>
+                <tr>
+                  <th>Description</th>
+                  <th>Type</th>
+                  <th>Quantity</th>
+                  <th>Price</th>
+                  <th>Amount</th>
+                </tr>
+              </thead>
+              <tbody data-items></tbody>
+              <tfoot>
+                <tr>
+                  <td colspan="4">Subtotal</td>
+                  <td data-summary="subtotal"></td>
+                </tr>
+                <tr>
+                  <td colspan="4">Tax</td>
+                  <td data-summary="tax"></td>
+                </tr>
+                <tr>
+                  <td colspan="4">Total due</td>
+                  <td data-summary="total"></td>
+                </tr>
+              </tfoot>
+            </table>
+
+            <div class="invoice__notes">
+              <div class="invoice__label">Notes</div>
+              <div data-field="notes"></div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <script src="./script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,410 @@
+const STORAGE_KEY = "invoice-builder-state-v1";
+const PDF_LIBRARY_SOURCES = [
+  "https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js",
+  "https://cdn.jsdelivr.net/npm/html2pdf.js@0.10.1/dist/html2pdf.bundle.min.js",
+];
+
+let pdfLibraryPromise = null;
+
+const defaultState = {
+  sellerName: "Acme Consulting Group",
+  sellerAddress: "123 Market Street\nSan Francisco, CA 94105\nUnited States",
+  sellerPhone: "+1 (555) 010-7788",
+  sellerEmail: "billing@acme.co",
+  clientName: "Globex Corporation",
+  clientContact:
+    "Attn: Accounts Payable\n987 Industry Way\nNew York, NY 10001\nUnited States",
+  invoiceNumber: "INV-2023-001",
+  issueDate: "2023-09-01",
+  dueDate: "2023-09-15",
+  currency: "USD",
+  paymentTerms: "Net 14",
+  balanceDue: "4000",
+  notes:
+    "Thank you for your business. Please submit payment by the due date listed above. If you have any questions, contact billing@acme.co.",
+  items: [
+    {
+      description: "Consulting services",
+      type: "Service",
+      quantity: "1",
+      unitPrice: "4000",
+      taxRate: "0",
+    },
+  ],
+};
+
+let state = loadState();
+
+const form = document.getElementById("invoiceForm");
+const itemsContainer = document.getElementById("itemsContainer");
+const preview = document.getElementById("invoicePreview");
+
+populateForm();
+renderItemsForm();
+renderPreview();
+
+bindFormFields();
+
+ensurePdfLibrary().catch((error) => {
+  console.warn("Unable to pre-load the PDF export library", error);
+});
+
+function loadState() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      return { ...cloneValue(defaultState), ...parsed };
+    }
+  } catch (error) {
+    console.warn("Unable to load saved invoice data", error);
+  }
+  return cloneValue(defaultState);
+}
+
+function saveState() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function cloneValue(value) {
+  if (typeof window.structuredClone === "function") {
+    return window.structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function ensurePdfLibrary() {
+  if (typeof window === "undefined") {
+    return Promise.reject(
+      new Error("PDF export is not available in this environment.")
+    );
+  }
+
+  if (typeof window.html2pdf === "function") {
+    return Promise.resolve(window.html2pdf);
+  }
+
+  if (!pdfLibraryPromise) {
+    pdfLibraryPromise = new Promise((resolve, reject) => {
+      let attemptIndex = 0;
+      const target =
+        document.head || document.getElementsByTagName("head")[0] || document.body;
+
+      const loadNext = () => {
+        if (typeof window.html2pdf === "function") {
+          resolve(window.html2pdf);
+          return;
+        }
+
+        if (attemptIndex >= PDF_LIBRARY_SOURCES.length) {
+          reject(new Error("Unable to load the PDF export library."));
+          return;
+        }
+
+        const url = PDF_LIBRARY_SOURCES[attemptIndex++];
+        const script = document.createElement("script");
+        script.src = url;
+        script.async = true;
+        script.crossOrigin = "anonymous";
+        script.referrerPolicy = "no-referrer";
+        script.onload = () => {
+          if (typeof window.html2pdf === "function") {
+            resolve(window.html2pdf);
+          } else {
+            script.remove();
+            loadNext();
+          }
+        };
+        script.onerror = () => {
+          script.remove();
+          loadNext();
+        };
+
+        target.appendChild(script);
+      };
+
+      loadNext();
+    }).catch((error) => {
+      pdfLibraryPromise = null;
+      throw error;
+    });
+  }
+
+  return pdfLibraryPromise;
+}
+
+function populateForm() {
+  for (const [name, value] of Object.entries(state)) {
+    if (name === "items") continue;
+    const input = form.elements.namedItem(name);
+    if (input) {
+      input.value = value ?? "";
+    }
+  }
+}
+
+function bindFormFields() {
+  const fields = form.querySelectorAll("input, textarea");
+  fields.forEach((field) => {
+    if (field.name === "") return;
+    field.addEventListener("input", () => {
+      if (field.name === "balanceDue") {
+        state[field.name] = field.value.trim();
+      } else {
+        state[field.name] = field.value;
+      }
+      renderPreview();
+      saveState();
+    });
+  });
+
+  document
+    .getElementById("addItem")
+    .addEventListener("click", () => addItemRow());
+
+  document
+    .getElementById("downloadPdf")
+    .addEventListener("click", handleDownloadPdf);
+
+  document.getElementById("resetState").addEventListener("click", () => {
+    if (confirm("Reset all invoice data and restore the default values?")) {
+      state = cloneValue(defaultState);
+      saveState();
+      populateForm();
+      renderItemsForm();
+      renderPreview();
+    }
+  });
+}
+
+function renderItemsForm() {
+  itemsContainer.innerHTML = "";
+  state.items.forEach((item, index) => {
+    const row = document.createElement("div");
+    row.className = "item-row";
+    row.innerHTML = `
+      <div class="item-row__field">
+        <label class="field__label">Description</label>
+        <input class="field__input" name="description" value="${escapeHtml(
+          item.description || ""
+        )}" />
+      </div>
+      <div class="item-row__field">
+        <label class="field__label">Type</label>
+        <input class="field__input" name="type" value="${escapeHtml(
+          item.type || ""
+        )}" />
+      </div>
+      <div class="item-row__field">
+        <label class="field__label">Quantity</label>
+        <input class="field__input" name="quantity" type="number" min="0" step="0.01" value="${
+          item.quantity || ""
+        }" />
+      </div>
+      <div class="item-row__field">
+        <label class="field__label">Price</label>
+        <input class="field__input" name="unitPrice" type="number" min="0" step="0.01" value="${
+          item.unitPrice || ""
+        }" />
+      </div>
+      <div class="item-row__field">
+        <label class="field__label">Tax %</label>
+        <input class="field__input" name="taxRate" type="number" min="0" step="0.1" value="${
+          item.taxRate || ""
+        }" />
+      </div>
+      <button type="button" class="item-row__remove" aria-label="Remove line item">✕</button>
+    `;
+
+    row.querySelectorAll("input").forEach((input) => {
+      input.addEventListener("input", (event) => {
+        const target = event.currentTarget;
+        state.items[index][target.name] = target.value;
+        renderPreview();
+        saveState();
+      });
+    });
+
+    row.querySelector(".item-row__remove").addEventListener("click", () => {
+      if (state.items.length === 1) {
+        state.items[0] = cloneValue(defaultState.items[0]);
+      } else {
+        state.items.splice(index, 1);
+      }
+      renderItemsForm();
+      renderPreview();
+      saveState();
+    });
+
+    itemsContainer.appendChild(row);
+  });
+}
+
+function addItemRow() {
+  state.items.push({
+    description: "",
+    type: "",
+    quantity: "1",
+    unitPrice: "0",
+    taxRate: "0",
+  });
+  renderItemsForm();
+  renderPreview();
+  saveState();
+}
+
+function renderPreview() {
+  const fieldNodes = preview.querySelectorAll("[data-field]");
+  fieldNodes.forEach((node) => {
+    const key = node.getAttribute("data-field");
+    let value = state[key] ?? "";
+
+    if (key === "balanceDue") {
+      value = formatCurrency(value);
+    }
+
+    if (key === "issueDate" || key === "dueDate") {
+      value = formatDate(value);
+    }
+
+    node.textContent = value;
+  });
+
+  const tbody = preview.querySelector("[data-items]");
+  tbody.innerHTML = "";
+
+  let subtotal = 0;
+  let taxTotal = 0;
+
+  state.items.forEach((item) => {
+    const quantity = parseFloat(item.quantity) || 0;
+    const unitPrice = parseFloat(item.unitPrice) || 0;
+    const taxRate = parseFloat(item.taxRate) || 0;
+    const lineTotal = quantity * unitPrice;
+    const lineTax = lineTotal * (taxRate / 100);
+
+    subtotal += lineTotal;
+    taxTotal += lineTax;
+
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td>${escapeHtml(item.description || "")}</td>
+      <td>${escapeHtml(item.type || "")}</td>
+      <td>${formatNumber(quantity)}</td>
+      <td>${formatCurrency(unitPrice)}</td>
+      <td>${formatCurrency(lineTotal)}</td>
+    `;
+
+    tbody.appendChild(row);
+  });
+
+  const summaryNodes = preview.querySelectorAll("[data-summary]");
+  summaryNodes.forEach((node) => {
+    const key = node.getAttribute("data-summary");
+    if (key === "subtotal") {
+      node.textContent = formatCurrency(subtotal);
+    }
+    if (key === "tax") {
+      node.textContent = formatCurrency(taxTotal);
+    }
+    if (key === "total") {
+      node.textContent = formatCurrency(subtotal + taxTotal);
+    }
+  });
+}
+
+function formatCurrency(value) {
+  const amount = typeof value === "string" ? parseFloat(value) : value;
+  if (Number.isNaN(amount) || amount === null) {
+    return "";
+  }
+  const currency = state.currency || "USD";
+  try {
+    const locale =
+      (typeof navigator !== "undefined" && navigator.language) || "en-US";
+    return new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency,
+      currencyDisplay: "symbol",
+      minimumFractionDigits: 2,
+    }).format(amount);
+  } catch (error) {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+}
+
+function formatNumber(value) {
+  const locale =
+    (typeof navigator !== "undefined" && navigator.language) || "en-US";
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatDate(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  const locale =
+    (typeof navigator !== "undefined" && navigator.language) || "en-US";
+  return new Intl.DateTimeFormat(locale, {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  }).format(date);
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+async function handleDownloadPdf() {
+  const element = document.getElementById("invoicePreview");
+  const trigger = document.getElementById("downloadPdf");
+  const filename = `${state.invoiceNumber || "invoice"}.pdf`;
+  const options = {
+    margin: [10, 10, 10, 10],
+    filename,
+    image: { type: "jpeg", quality: 0.98 },
+    html2canvas: { scale: 2, useCORS: true },
+    jsPDF: { unit: "mm", format: "a4", orientation: "portrait" },
+  };
+
+  try {
+    document.body.classList.add("is-exporting");
+    if (trigger) {
+      trigger.disabled = true;
+      trigger.setAttribute("aria-busy", "true");
+    }
+    await ensurePdfLibrary();
+
+    if (typeof window.html2pdf !== "function") {
+      throw new Error("PDF export library unavailable after loading attempts.");
+    }
+
+    await window.html2pdf().set(options).from(element).save();
+  } catch (error) {
+    console.error("Failed to export invoice PDF", error);
+    if (typeof window.html2pdf !== "function") {
+      alert(
+        "The PDF export library could not be loaded. Please check your internet connection and try again."
+      );
+    } else {
+      alert("Something went wrong while creating the PDF. Please try again.");
+    }
+  } finally {
+    document.body.classList.remove("is-exporting");
+    if (trigger) {
+      trigger.disabled = false;
+      trigger.removeAttribute("aria-busy");
+    }
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,353 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  font-size: 16px;
+  line-height: 1.4;
+  --color-bg: #f5f6fb;
+  --color-panel: #ffffff;
+  --color-border: #dce0eb;
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-text: #1f2937;
+  --color-text-secondary: #6b7280;
+  --shadow-sm: 0 6px 24px rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+body.is-exporting {
+  cursor: progress;
+}
+
+body.is-exporting button {
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.page__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.page__title {
+  font-size: 32px;
+  margin: 0;
+}
+
+.page__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.page__content {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: start;
+}
+
+.panel {
+  background: var(--color-panel);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.panel__title {
+  font-size: 20px;
+  margin: 0;
+  font-weight: 600;
+}
+
+.button {
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 15px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.button[disabled] {
+  opacity: 0.65;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.button--primary {
+  color: #fff;
+  background: var(--color-primary);
+}
+
+.button--primary:hover {
+  background: var(--color-primary-hover);
+}
+
+.button--secondary {
+  color: var(--color-primary);
+  background: rgba(37, 99, 235, 0.1);
+  border-color: rgba(37, 99, 235, 0.3);
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--color-primary);
+  border-color: var(--color-border);
+}
+
+.button--ghost:hover {
+  border-color: var(--color-primary);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.fieldset__title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin-bottom: 4px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field__label {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+}
+
+.field__input {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--color-border);
+  font: inherit;
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field__input:focus {
+  border-color: var(--color-primary);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.field__input--textarea {
+  min-height: 72px;
+  resize: vertical;
+}
+
+.field--grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.item-row {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 2fr 1fr 1fr 1fr auto;
+  align-items: end;
+}
+
+.item-row__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.item-row__remove {
+  background: none;
+  border: none;
+  color: #ef4444;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 6px;
+  transition: background 0.2s ease;
+}
+
+.item-row__remove:hover {
+  background: rgba(239, 68, 68, 0.12);
+}
+
+.panel--preview {
+  position: sticky;
+  top: 24px;
+}
+
+.invoice {
+  background: #fff;
+  border-radius: 12px;
+  padding: 32px;
+  color: var(--color-text);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.invoice__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.invoice__seller-name {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.invoice__seller-address,
+.invoice__seller-contact div {
+  color: var(--color-text-secondary);
+  white-space: pre-line;
+}
+
+.invoice__meta {
+  text-align: right;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.invoice__title {
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.invoice__label {
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.invoice__balance span:last-child,
+.invoice__number span:last-child {
+  font-size: 18px;
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.invoice__info {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 18px;
+}
+
+.invoice__billto {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.invoice__billto-name {
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.invoice__billto-contact {
+  color: var(--color-text-secondary);
+  white-space: pre-line;
+}
+
+.invoice__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.invoice__table th,
+.invoice__table td {
+  border-bottom: 1px solid var(--color-border);
+  padding: 12px 8px;
+  text-align: left;
+}
+
+.invoice__table th {
+  background: rgba(15, 23, 42, 0.04);
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.05em;
+}
+
+.invoice__table td:last-child,
+.invoice__table th:last-child {
+  text-align: right;
+}
+
+.invoice__table tfoot td {
+  font-weight: 600;
+}
+
+.invoice__notes {
+  border-top: 1px solid var(--color-border);
+  padding-top: 16px;
+  color: var(--color-text-secondary);
+  white-space: pre-line;
+}
+
+@media (max-width: 900px) {
+  .panel--preview {
+    position: static;
+  }
+
+  .invoice__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .invoice__meta {
+    text-align: left;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- load the html2pdf bundle on demand with fallback CDN sources so the exporter works when the primary script fails
- await the loader in the export handler and surface clearer messaging when the library cannot be prepared
- remove the static CDN script tag because the loader now manages importing the PDF dependency

## Testing
- not run (static page)

------
https://chatgpt.com/codex/tasks/task_e_68dc4f5e02708325a9fcb54bf3adb890